### PR TITLE
Update to NodeJS 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ inputs:
     default: 'pre-commit fixes'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
## what

- Run action on NodeJS v20

## why

- GitHub has deprectated NodeJS v16 and so an upgrade is needed. v20 is the current recommended version.

